### PR TITLE
Update RediStack package URL

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -66,7 +66,7 @@
     {
       "identity" : "redistack",
       "kind" : "remoteSourceControl",
-      "location" : "https://gitlab.com/mordil/RediStack.git",
+      "location" : "https://github.com/swift-server/RediStack.git",
       "state" : {
         "revision" : "3f7fedb6db5dfcb12bd2263dfaaec108b250ec79",
         "version" : "2.0.0-gamma.1"

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/d-exclaimation/pioneer", from: "1.0.0"),
-        .package(url: "https://github.com/swift-server/RediStack.git", from: "2.0.0-gamma.1"),
+        .package(url: "https://github.com/swift-server/RediStack.git", from: "1.4.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/d-exclaimation/pioneer", from: "1.0.0"),
-        .package(url: "https://gitlab.com/swift-server/RediStack.git", from: "2.0.0-gamma.1"),
+        .package(url: "https://github.com/swift-server/RediStack.git", from: "2.0.0-gamma.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/d-exclaimation/pioneer", from: "1.0.0"),
-        .package(url: "https://gitlab.com/mordil/RediStack.git", from: "2.0.0-gamma.1"),
+        .package(url: "https://gitlab.com/swift-server/RediStack.git", from: "2.0.0-gamma.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Solves this warning which appears when using PioneerRedisPubSub together with Vapor’s Redis client:

> :warning: 'redis' dependency on 'https://github.com/swift-server/RediStack.git' conflicts with dependency on 'https://gitlab.com/mordil/RediStack.git' which has the same identity 'redistack'. this will be escalated to an error in future versions of SwiftPM.